### PR TITLE
Enhanced Export JSON File naming format

### DIFF
--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -380,7 +380,7 @@ window.onload = function() {
 
 		let downloadJsonFile = document.createElement("a")
 		downloadJsonFile.href = url
-		downloadJsonFile.download = `${fileName}.json`
+		downloadJsonFile.download = fileName
 		downloadJsonFile.click()
 
 		URL.revokeObjectURL(url)


### PR DESCRIPTION
Fixes issue #6 

First Article Inspection Report now exports as a JSON file with a naming scheme in the requested format such as `fair_<Part #><Rev.>_<Current date>,json`.

The date follows the ISO 8601 Date Format (YYYY-MM-DD).

Tested with different input combinations:

**Example 1: all inputs contain values**
- Part #: `123456-78`
- Rev.: `3`
- Current date is `2024-11-20`

The resulting exported JSON file is named `fair_123456-78rev3_2024-11-21.json`.

**Example 2: all inputs contain values**
- Part #: `123456-78`
- Rev.: `AB`
- Current date is `2024-11-20`

The resulting exported JSON file is named `fair_123456-78revAB_2024-11-21.json`.

**Example 3: all inputs contain values**
- Part #: `123456-ABC`
- Rev.: `AB`
- Current date is `2024-11-20`

The resulting exported JSON file is named `fair_123456-ABCrevAB_2024-11-21.json`.

**Example 4: no value in the Part # input**
- Part #: ` `
- Rev.: `3`
- Current date is `2024-11-20`

The resulting exported JSON file is named `fair_rev3_2024-11-21.json`.

**Example 5: no value in the Rev. input**
- Part #: `123456-78`
- Rev.: ` `
- Current date is `2024-11-20`

The resulting exported JSON file is named `fair_123456-78_2024-11-21.json`.

**Example 6: no values in both the Part # input and Rev. input**
- Part #: ` `
- Rev.: ` `
- Current date is `2024-11-20`

The resulting exported JSON file is named `fair__2024-11-21.json`.