### PR TITLE
Implement Company Name Field

### DIFF
--- a/first-article-inspection-report/first-article-inspection-report.html
+++ b/first-article-inspection-report/first-article-inspection-report.html
@@ -47,6 +47,20 @@ You should have received a copy of the GNU General Public License along with thi
 
 		<br>
 
+		<!-- Company Name -->
+		 <section class="table_company_name_section">
+			<table class="table_basic" id="table_company_name_info">
+				<thead>
+					<tr>
+						<th>Company Name</th>
+					</tr>
+				</thead>
+				<tbody>
+					<!-- The rows in this table body are added in javascript -->
+				</tbody>
+			</table>
+		 </section>
+
 		<!-- Info about the part -->
 		<section id="table_part_info_section">
 			<table class="table_basic" id="table_part_info">

--- a/first-article-inspection-report/first-article-inspection-report.html
+++ b/first-article-inspection-report/first-article-inspection-report.html
@@ -56,7 +56,7 @@ You should have received a copy of the GNU General Public License along with thi
 							<div class="company_name_container">
 								Company Name
 							</div>
-							<div class="reveal_container">
+							<div class="reveal_container no-print">
 								Reveal?
 								<input class="reasoncheckbox" type="checkbox" id="revealcheckbox"><label for="revealcheckbox"></label>
 							</div>

--- a/first-article-inspection-report/first-article-inspection-report.html
+++ b/first-article-inspection-report/first-article-inspection-report.html
@@ -47,14 +47,14 @@ You should have received a copy of the GNU General Public License along with thi
 
 		<br>
 
-		<!-- Company Name -->
-		 <section class="table_company_name_section">
-			<table class="table_basic" id="table_company_name_info">
+		<!-- Brand Name -->
+		 <section class="table_brand_name_section">
+			<table class="table_basic" id="table_brand_name_info">
 				<thead>
 					<tr>
 						<th>
-							<div class="company_name_container">
-								Company Name
+							<div class="brand_name_container">
+								Brand Name
 							</div>
 							<div class="reveal_container no-print">
 								Reveal?

--- a/first-article-inspection-report/first-article-inspection-report.html
+++ b/first-article-inspection-report/first-article-inspection-report.html
@@ -52,7 +52,16 @@ You should have received a copy of the GNU General Public License along with thi
 			<table class="table_basic" id="table_company_name_info">
 				<thead>
 					<tr>
-						<th>Company Name</th>
+						<th>
+							<div class="company_name_container">
+								Company Name
+							</div>
+							<div class="reveal_container">
+								Reveal?
+								<input class="reasoncheckbox" type="checkbox" id="revealcheckbox"><label for="revealcheckbox"></label>
+							</div>
+
+						</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -194,7 +194,7 @@ window.onload = function() {
 	 */
 	function brandNameVisibility() {
 
-		let brandNameInput = document.querySelector("input.brandname")
+		let brandNameInput = document.querySelector(".table_brand_name_section")
 			if (revealCheckBox.checked) {
 				brandNameInput.classList.remove("hide-brand-name")
 			} else {

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -196,9 +196,9 @@ window.onload = function() {
 
 		let brandNameInput = document.querySelector(".table_brand_name_section")
 			if (revealCheckBox.checked) {
-				brandNameInput.classList.remove("hide-brand-name")
+				brandNameInput.classList.remove("no-print")
 			} else {
-				brandNameInput.classList.add("hide-brand-name")
+				brandNameInput.classList.add("no-print")
 		}
 	}
 

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -186,6 +186,12 @@ window.onload = function() {
 
 	let revealCheckBox = document.getElementById("revealcheckbox")
 
+	/**
+	 * This function controls the visibility of the company name section in a table based on the state of the checkbox.
+	 *
+	 * When the `revealcheckbox` is checked, the function removes the "no-print" class from the company name table section, making it visible when printing
+	 * When unchecked, the function adds the "no-print" class from the company name table section, hiding the entire section when printing.
+	 */
 	function companyNameVisibility() {
 
 		let companyNameInput = document.querySelector(".table_company_name_section")

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -34,9 +34,9 @@ const json_schema_version = 1
  */
 const rowNumInitial = 28
 
-//The row of the table containing the company name
-let table_company_name_cell = [
-							   "<label><input type=\"text\" class=\"companyname\" ></input></label>",
+//The row of the table containing the brand name
+let table_brand_name_cell = [
+							   "<label><input type=\"text\" class=\"brandname\" ></input></label>",
 							  ]
 
 // The row of the table containing part information (part number, part description, etc.) will contain these cells
@@ -173,38 +173,38 @@ function rowFunc(row) {
 }
 
 window.onload = function() {
-	let table_company_name_info = new Table(document.getElementById("table_company_name_info"))
-	table_company_name_info.regHead(document.getElementById("table_company_name_info").thead, "head")
-	table_company_name_info.regBody(document.getElementById("table_company_name_info").getElementsByTagName("tbody")[0], "body")
+	let table_brand_name_info = new Table(document.getElementById("table_brand_name_info"))
+	table_brand_name_info.regHead(document.getElementById("table_brand_name_info").thead, "head")
+	table_brand_name_info.regBody(document.getElementById("table_brand_name_info").getElementsByTagName("tbody")[0], "body")
 
-	table_company_name_info.appendRows("body",
+	table_brand_name_info.appendRows("body",
 	                          1,
 	                          1,
 	                          parseInputCellsInRow,
-	                          arrayToGenerator(table_company_name_cell, 1)
+	                          arrayToGenerator(table_brand_name_cell, 1)
 	                          )
 
 	let revealCheckBox = document.getElementById("revealcheckbox")
 
 	/**
-	 * This function controls the visibility of the company name section in a table based on the state of the checkbox.
+	 * This function controls the visibility of the brand name section in a table based on the state of the checkbox.
 	 *
-	 * When the `revealcheckbox` is checked, the function removes the "no-print" class from the company name table section, making it visible when printing
-	 * When unchecked, the function adds the "no-print" class from the company name table section, hiding the entire section when printing.
+	 * When the `revealcheckbox` is checked, the function removes the "no-print" class from the brand name table section, making it visible when printing
+	 * When unchecked, the function adds the "no-print" class from the brand name table section, hiding the entire section when printing.
 	 */
-	function companyNameVisibility() {
+	function brandNameVisibility() {
 
-		let companyNameInput = document.querySelector(".table_company_name_section")
+		let brandNameInput = document.querySelector("input.brandname")
 			if (revealCheckBox.checked) {
-				companyNameInput.classList.remove("no-print")
+				brandNameInput.classList.remove("hide-brand-name")
 			} else {
-				companyNameInput.classList.add("no-print")
+				brandNameInput.classList.add("hide-brand-name")
 		}
 	}
 
-	companyNameVisibility()
+	brandNameVisibility()
 
-	revealCheckBox.addEventListener("change", companyNameVisibility)
+	revealCheckBox.addEventListener("change", brandNameVisibility)
 
 	let table_part_info = new Table(document.getElementById("table_part_info"))
 	table_part_info.regHead(document.getElementById("table_part_info").tHead, "head")
@@ -395,9 +395,9 @@ window.onload = function() {
 			partSerial: row.cells[4].querySelector('.partserial') ? row.cells[4].querySelector('.partserial').value : '',
 		}))
 
-		// Collect data from company name table and also allows for blank inputs
-		let companyNameInput = document.querySelector("input.companyname")
-		let companyNameValue = companyNameInput ? companyNameInput.value : ""
+		// Collect data from brand name table and also allows for blank inputs
+		let brandNameInput = document.querySelector("input.brandname")
+		let brandNameValue = brandNameInput ? brandNameInput.value : ""
 
 		/* Include the Reveal checkbox in the object
 		If the checkbox is unchecked, the value will be false
@@ -406,7 +406,7 @@ window.onload = function() {
 		let revealCheckBox = document.getElementById('revealcheckbox')
 		let isRevealChecked = revealCheckBox.checked
 
-		let companyData = isRevealChecked ? companyNameValue : ""
+		let brandData = isRevealChecked ? brandNameValue : ""
 
 		// Collect data from main inspection table and also allows for blank inputs
 		let mainTable = document.getElementById("table_main")
@@ -423,7 +423,7 @@ window.onload = function() {
 		let jsonData = {
 			meta: { schemaVersion: json_schema_version },
 			reasons: reasonCheckboxes(),
-			companyName: companyData,
+			brandName: brandData,
 			revealChecked: isRevealChecked,
 			partInfo: partInfoData,
 			mainData: mainData,
@@ -432,12 +432,12 @@ window.onload = function() {
 
 		let jsonString = JSON.stringify(jsonData, null, 2)
 
-		let companyName = companyNameValue ? `_${companyNameValue}` : ""
+		let brandName = brandNameValue ? `_${brandNameValue}` : ""
 		let partNum = partInfoData[0]?.partNum || ""
 		let partRev = partInfoData[0]?.partRev ? `rev${partInfoData[0]?.partRev}` : ""
 		let currentDate = new Date().toISOString().split('T')[0]
 
-		let fileName = `fair${companyName}_${partNum}${partRev}_${currentDate}`
+		let fileName = `fair${brandName}_${partNum}${partRev}_${currentDate}`
 
 		// Create a blob and download the file
 		let blob = new Blob([jsonString], { type: "application/json" })
@@ -501,10 +501,10 @@ window.onload = function() {
 						return
 					}
 
-					// Populate the company name table
-					const companyNameInput = document.querySelector("input.companyname")
-					if (companyNameInput) {
-						companyNameInput.value = jsonData.companyName || ""
+					// Populate the brand name table
+					const brandNameInput = document.querySelector("input.brandname")
+					if (brandNameInput) {
+						brandNameInput.value = jsonData.brandName || ""
 					}
 
 					/**

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -36,7 +36,7 @@ const rowNumInitial = 28
 
 //The row of the table containing the company name
 let table_company_name_cell = [
-							  "<label><input type=\"text\" class=\"companyname\" ></input></label>",
+							   "<label><input type=\"text\" class=\"companyname\" ></input></label>",
 							  ]
 
 // The row of the table containing part information (part number, part description, etc.) will contain these cells

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -37,6 +37,7 @@ const rowNumInitial = 28
 //The row of the table containing the company name
 let table_company_name_cell = [
 							   "<label><input type=\"text\" class=\"companyname\" ></input></label>",
+							//    "<label><input type=\"checkbox\" class=\"revealcheckbox\" ></input></label>"
 							  ]
 
 // The row of the table containing part information (part number, part description, etc.) will contain these cells

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -394,6 +394,8 @@ window.onload = function() {
 		let companyData = ''
 
 		let revealCheckBox = document.getElementById('revealcheckbox')
+		let isRevealChecked = revealCheckBox.checked;
+
 		if (revealCheckBox.checked && companyNameInput) {
 			companyData = companyNameInput.value;
 		}
@@ -414,6 +416,7 @@ window.onload = function() {
 			meta: { schemaVersion: json_schema_version },
 			reasons: reasonCheckboxes(),
 			companyName: companyData,
+			revealChecked: isRevealChecked,
 			partInfo: partInfoData,
 			mainData: mainData,
 			comments: document.getElementById("commentTextBox") ? document.getElementById("commentTextBox").value : ''

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -389,6 +389,15 @@ window.onload = function() {
 			partSerial: row.cells[4].querySelector('.partserial') ? row.cells[4].querySelector('.partserial').value : '',
 		}))
 
+		// Collect data from company name table and also allows for blank inputs
+		let companyNameInput = document.querySelector("input.companyname")
+		let companyData = ''
+
+		let revealCheckBox = document.getElementById('revealcheckbox')
+		if (revealCheckBox.checked && companyNameInput) {
+			companyData = companyNameInput.value;
+		}
+
 		// Collect data from main inspection table and also allows for blank inputs
 		let mainTable = document.getElementById("table_main")
 		let mainData = Array.from(mainTable.rows).slice(1).map(row => ({
@@ -404,6 +413,7 @@ window.onload = function() {
 		let jsonData = {
 			meta: { schemaVersion: json_schema_version },
 			reasons: reasonCheckboxes(),
+			companyName: companyData,
 			partInfo: partInfoData,
 			mainData: mainData,
 			comments: document.getElementById("commentTextBox") ? document.getElementById("commentTextBox").value : ''

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -391,7 +391,7 @@ window.onload = function() {
 
 		// Collect data from company name table and also allows for blank inputs
 		let companyNameInput = document.querySelector("input.companyname")
-		let companyData = ''
+		let companyNameValue = companyNameInput ? companyNameInput.value : ""
 
 		/* Include the Reveal checkbox in the object
 		If the checkbox is unchecked, the value will be false
@@ -400,9 +400,7 @@ window.onload = function() {
 		let revealCheckBox = document.getElementById('revealcheckbox')
 		let isRevealChecked = revealCheckBox.checked;
 
-		if (revealCheckBox.checked && companyNameInput) {
-			companyData = companyNameInput.value;
-		}
+		let companyData = isRevealChecked ? companyNameValue : ""
 
 		// Collect data from main inspection table and also allows for blank inputs
 		let mainTable = document.getElementById("table_main")
@@ -428,7 +426,7 @@ window.onload = function() {
 
 		let jsonString = JSON.stringify(jsonData, null, 2)
 
-		let companyName = companyData ? `_${companyData}` : ""
+		let companyName = companyNameValue ? `_${companyNameValue}` : ""
 		let partNum = partInfoData[0]?.partNum || ""
 		let partRev = partInfoData[0]?.partRev ? `rev${partInfoData[0]?.partRev}` : ""
 		let currentDate = new Date().toISOString().split('T')[0]

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -37,7 +37,6 @@ const rowNumInitial = 28
 //The row of the table containing the company name
 let table_company_name_cell = [
 							   "<label><input type=\"text\" class=\"companyname\" ></input></label>",
-							//    "<label><input type=\"checkbox\" class=\"revealcheckbox\" ></input></label>"
 							  ]
 
 // The row of the table containing part information (part number, part description, etc.) will contain these cells
@@ -184,6 +183,22 @@ window.onload = function() {
 	                          parseInputCellsInRow,
 	                          arrayToGenerator(table_company_name_cell, 1)
 	                          )
+
+	let revealCheckBox = document.getElementById("revealcheckbox")
+
+	function companyNameVisibility() {
+
+		let companyNameInput = document.querySelector("input.companyname")
+			if (revealCheckBox.checked) {
+				companyNameInput.classList.remove("hide-company-name")
+			} else {
+				companyNameInput.classList.add("hide-company-name")
+		}
+	}
+
+	companyNameVisibility()
+
+	revealCheckBox.addEventListener("change", companyNameVisibility)
 
 	let table_part_info = new Table(document.getElementById("table_part_info"))
 	table_part_info.regHead(document.getElementById("table_part_info").tHead, "head")

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -428,11 +428,12 @@ window.onload = function() {
 
 		let jsonString = JSON.stringify(jsonData, null, 2)
 
+		let companyName = companyData ? `_${companyData}` : ""
 		let partNum = partInfoData[0]?.partNum || ""
 		let partRev = partInfoData[0]?.partRev ? `rev${partInfoData[0]?.partRev}` : ""
 		let currentDate = new Date().toISOString().split('T')[0]
 
-		let fileName = `fair_${partNum}${partRev}_${currentDate}`
+		let fileName = `fair${companyName}_${partNum}${partRev}_${currentDate}`
 
 		// Create a blob and download the file
 		let blob = new Blob([jsonString], { type: "application/json" })

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -398,7 +398,7 @@ window.onload = function() {
 		If the checkbox is checked, the value will be true
 		*/
 		let revealCheckBox = document.getElementById('revealcheckbox')
-		let isRevealChecked = revealCheckBox.checked;
+		let isRevealChecked = revealCheckBox.checked
 
 		let companyData = isRevealChecked ? companyNameValue : ""
 
@@ -508,7 +508,7 @@ window.onload = function() {
 					 * */
 					const revealCheckBox = document.getElementById("revealcheckbox")
 					if (revealCheckBox) {
-						revealCheckBox.checked = jsonData.revealChecked || false;
+						revealCheckBox.checked = jsonData.revealChecked || false
 					}
 
 					// Populate the part info table

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -34,6 +34,11 @@ const json_schema_version = 1
  */
 const rowNumInitial = 28
 
+//The row of the table containing the company name
+let table_company_name_cell = [
+							  "<label><input type=\"text\" class=\"companyname\" ></input></label>",
+							  ]
+
 // The row of the table containing part information (part number, part description, etc.) will contain these cells
 let table_part_info_cells = [
                              "<label><input type=\"text\" class=\"partnum\" ></input></label>",
@@ -168,6 +173,17 @@ function rowFunc(row) {
 }
 
 window.onload = function() {
+	let table_company_name_info = new Table(document.getElementById("table_company_name_info"))
+	table_company_name_info.regHead(document.getElementById("table_company_name_info").thead, "head")
+	table_company_name_info.regBody(document.getElementById("table_company_name_info").getElementsByTagName("tbody")[0], "body")
+
+	table_company_name_info.appendRows("body",
+	                          1,
+	                          1,
+	                          parseInputCellsInRow,
+	                          arrayToGenerator(table_company_name_cell, 1)
+	                          )
+
 	let table_part_info = new Table(document.getElementById("table_part_info"))
 	table_part_info.regHead(document.getElementById("table_part_info").tHead, "head")
 	table_part_info.regBody(document.getElementById("table_part_info").getElementsByTagName("tbody")[0], "body")

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -489,6 +489,12 @@ window.onload = function() {
 						return
 					}
 
+					// Populate the company name table
+					const companyNameInput = document.querySelector("input.companyname")
+					if (companyNameInput) {
+						companyNameInput.value = jsonData.companyName || ""
+					}
+
 					// Populate the part info table
 					const partInfoTable = document.getElementById("table_part_info")
 					jsonData.partInfo.forEach((part, index) => {

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -502,6 +502,16 @@ window.onload = function() {
 						companyNameInput.value = jsonData.companyName || ""
 					}
 
+					/**
+					 * Populate the data for the state of the reveal checkbox
+					 * If the checkbox is checked, the value will be true,
+					 * If the checkbox is unchecked, the value will be false
+					 * */
+					const revealCheckBox = document.getElementById("revealcheckbox")
+					if (revealCheckBox) {
+						revealCheckBox.checked = jsonData.revealChecked || false;
+					}
+
 					// Populate the part info table
 					const partInfoTable = document.getElementById("table_part_info")
 					jsonData.partInfo.forEach((part, index) => {

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -393,6 +393,10 @@ window.onload = function() {
 		let companyNameInput = document.querySelector("input.companyname")
 		let companyData = ''
 
+		/* Include the Reveal checkbox in the object
+		If the checkbox is unchecked, the value will be false
+		If the checkbox is checked, the value will be true
+		*/
 		let revealCheckBox = document.getElementById('revealcheckbox')
 		let isRevealChecked = revealCheckBox.checked;
 

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -188,11 +188,11 @@ window.onload = function() {
 
 	function companyNameVisibility() {
 
-		let companyNameInput = document.querySelector("input.companyname")
+		let companyNameInput = document.querySelector(".table_company_name_section")
 			if (revealCheckBox.checked) {
-				companyNameInput.classList.remove("hide-company-name")
+				companyNameInput.classList.remove("no-print")
 			} else {
-				companyNameInput.classList.add("hide-company-name")
+				companyNameInput.classList.add("no-print")
 		}
 	}
 

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -406,7 +406,7 @@ window.onload = function() {
 		let revealCheckBox = document.getElementById('revealcheckbox')
 		let isRevealChecked = revealCheckBox.checked
 
-		let brandData = isRevealChecked ? brandNameValue : ""
+		// let brandData = isRevealChecked ? brandNameValue : ""
 
 		// Collect data from main inspection table and also allows for blank inputs
 		let mainTable = document.getElementById("table_main")
@@ -423,9 +423,13 @@ window.onload = function() {
 		let jsonData = {
 			meta: { schemaVersion: json_schema_version },
 			reasons: reasonCheckboxes(),
-			brandName: brandData,
-			revealChecked: isRevealChecked,
-			partInfo: partInfoData,
+			partInfo: partInfoData.map( info => ({
+				partBrandName: {
+					name: brandNameValue,
+					reveal: isRevealChecked
+				},
+				...info,
+			})),
 			mainData: mainData,
 			comments: document.getElementById("commentTextBox") ? document.getElementById("commentTextBox").value : ''
 		}

--- a/first-article-inspection-report/style.css
+++ b/first-article-inspection-report/style.css
@@ -50,6 +50,11 @@ body {
 	input {
 		border: 0px !important;
 	}
+
+	.hide-brand-name {
+		visibility: hidden !important;
+	}
+
 }
 
 h1, h2, h3 {
@@ -102,7 +107,7 @@ h1, h2, h3 {
 	font-weight: lighter;
 }
 
-.company_name_container{
+.brand_name_container{
 	text-align: center;
 }
 
@@ -128,13 +133,13 @@ h1, h2, h3 {
 	background-color: whitesmoke;
 }
 
-#table_company_name_info {
+#table_brand_name_info {
 	margin-left: auto;
 	margin-right: auto;
 	margin-bottom: 20px;
 }
 
-#table_company_name_info th {
+#table_brand_name_info th {
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -144,7 +149,7 @@ h1, h2, h3 {
 	gap: 40px;
 }
 
-#table_company_name_info div {
+#table_brand_name_info div {
 	display: flex;
 	align-items: center;
 }
@@ -171,8 +176,8 @@ input {
 	text-align: center;
 }
 
-/* Styles for cells in the table_company_name_info table */
-.companyname {
+/* Styles for cells in the table_brand_name_info table */
+.brandname {
 	width: 50em;
 }
 

--- a/first-article-inspection-report/style.css
+++ b/first-article-inspection-report/style.css
@@ -50,6 +50,11 @@ body {
 	input {
 		border: 0px !important;
 	}
+
+	.hide-company-name {
+		visibility: hidden !important;
+	}
+
 }
 
 h1, h2, h3 {
@@ -128,7 +133,7 @@ h1, h2, h3 {
 	align-items: center;
 	padding-bottom: 5px;
 	flex-direction: row;
-	gap: 20px;
+	gap: 30px;
 }
 
 #table_company_name_info div {

--- a/first-article-inspection-report/style.css
+++ b/first-article-inspection-report/style.css
@@ -115,6 +115,12 @@ h1, h2, h3 {
 	background-color: whitesmoke;
 }
 
+#table_company_name_info {
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 20px;
+}
+
 #table_part_info {
 	margin-left: auto;
 	margin-right: auto;
@@ -138,6 +144,9 @@ input {
 }
 
 /* Styles for cells in the table_part_info table */
+.companyname {
+	width: 50em;
+}
 .partnum {
 	width: 9em;
 }

--- a/first-article-inspection-report/style.css
+++ b/first-article-inspection-report/style.css
@@ -98,6 +98,18 @@ h1, h2, h3 {
 	content: "✓";
 }
 
+/* "Reveal" section */
+.reveal_container {
+	font-size: 12px;
+	position: absolute;
+	right: 0;
+	padding-right: 5px;
+}
+
+.company_name_container{
+	text-align: center;
+}
+
 /* Table stylings */
 .table_basic {
 	table-layout: auto;
@@ -127,17 +139,16 @@ h1, h2, h3 {
 }
 
 #table_company_name_info th {
-	/* border: 2px solid red; */
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	position: relative;
 	padding-bottom: 5px;
 	flex-direction: row;
-	gap: 30px;
+	gap: 40px;
 }
 
 #table_company_name_info div {
-	/* border: 2px solid blue; */
 	display: flex;
 	align-items: center;
 }

--- a/first-article-inspection-report/style.css
+++ b/first-article-inspection-report/style.css
@@ -121,6 +121,22 @@ h1, h2, h3 {
 	margin-bottom: 20px;
 }
 
+#table_company_name_info th {
+	/* border: 2px solid red; */
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	padding-bottom: 5px;
+	flex-direction: row;
+	gap: 20px;
+}
+
+#table_company_name_info div {
+	/* border: 2px solid blue; */
+	display: flex;
+	align-items: center;
+}
+
 #table_part_info {
 	margin-left: auto;
 	margin-right: auto;

--- a/first-article-inspection-report/style.css
+++ b/first-article-inspection-report/style.css
@@ -50,11 +50,6 @@ body {
 	input {
 		border: 0px !important;
 	}
-
-	.hide-company-name {
-		visibility: hidden !important;
-	}
-
 }
 
 h1, h2, h3 {

--- a/first-article-inspection-report/style.css
+++ b/first-article-inspection-report/style.css
@@ -143,10 +143,12 @@ input {
 	text-align: center;
 }
 
-/* Styles for cells in the table_part_info table */
+/* Styles for cells in the table_company_name_info table */
 .companyname {
 	width: 50em;
 }
+
+/* Styles for cells in the table_part_info table */
 .partnum {
 	width: 9em;
 }

--- a/first-article-inspection-report/style.css
+++ b/first-article-inspection-report/style.css
@@ -104,6 +104,7 @@ h1, h2, h3 {
 	position: absolute;
 	right: 0;
 	padding-right: 5px;
+	font-weight: lighter;
 }
 
 .company_name_container{


### PR DESCRIPTION
Fixes issue #8 

## Company Name Field UI
Implement a new table `Company Name` above the `Part Info` table
* Allows for input of the company name, if there is one.

Add a checkbox labeled `Reveal?` adjacent to the table.
 * If the checkbox is checked, the company name table and input will appear when printing the report.
 * Otherwise, if left unchecked, the company name table will _not_appear when printing the report.

* The `Reveal?` checkbox will be hidden when printing the report, regardless of whether it is checked or not

## JSON files Behavior
When exporting the report as a JSON file, `Company Name` and `Reveal?` are now included in the object.
* If the company name is included, it will include `"company name" as the key and the inputted company name as a string value.
* If the company name is _not_ included (there is no input for the company name), the exported JSON file will still include the object with a key of `"company name" and a value of an empty string ('').


* In the object, include whether the `Reveal?` checkbox is checked or not.
  * False = unchecked, the company name is _not_ included when printing.
  * True = checked, the company name is included when printing.

* If a `Company Name` is provided:
  * The name of the JSON file will include the company name in the format `fair_<company name>_<part number and rev>_<date>.json`.


