### PR TITLE
fair: Dynamically add rows to the main table when importing JSON files

### DIFF
--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -496,6 +496,11 @@ window.onload = function() {
 					let mainTableRowsCount = mainTable.rows.length - 1
 					let neededRows = jsonData.mainData.length
 
+					// Remove any extra rows that are not in the imported file
+					for (let i = mainTableRowsCount; i > neededRows; i--) {
+						mainTable.deleteRow(i)
+					}
+
 					for (let i = mainTableRowsCount; i < neededRows; i++) {
 						let newRow = mainTable.insertRow()
 						for (let j = 0; j < mainTableColumnsCount; j++) {

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -105,54 +105,9 @@ function parseInputCellsInRow(row) {
 		node.addEventListener("blur", function() {
 			node.value = replaceSubstringMap(node.value, mathMap)
 		})
-
-		node.addEventListener('keydown', function(event) {
-			if (event.key === "Enter") {
-				event.preventDefault()
-
-				let nextInput = goToNextInput(node)
-				if (nextInput) {
-					nextInput.focus()
-				}
-			}
-		})
 	}
 }
 
-/** Finds the next input in the same column of the following row in the table, allowing
- *  users to navigate to the next input by pressing the 'Enter' key.
- *
- * This function is used to enable keyboard navigation within a table, moving to the next
- * input field directly below the current one.
- *
- * @param {object} currentInput - The current input DOM element where 'Enter' is pressed.
-*/
-function goToNextInput(currentInput) {
-	// Get the current row and column of the current input
-	let currentRow = currentInput.closest('tr')
-	let currentColumn = Array.from(currentInput.closest('td').parentNode.children)
-	let currentColumnIndex = currentColumn.indexOf(currentInput.closest('td'))
-
-	let tableBody = currentRow.closest('tbody')
-
-	let allRows = Array.from(tableBody.querySelectorAll('tr'))
-
-	let currentRowIndex = allRows.indexOf(currentRow)
-
-	// Check if there is a next row
-	if (currentRowIndex < allRows.length - 1) {
-		let nextRow = allRows[currentRowIndex + 1]
-
-		// Get the next input in the same column in the next row
-		let nextInput = nextRow.cells[currentColumnIndex].querySelector('input[type="text"]')
-
-		if (nextInput) {
-			return nextInput
-		}
-	}
-
-	return null
-}
 
 /**
  * This function simply runs other functions that should be called on rows in a table.
@@ -580,7 +535,29 @@ window.onload = function() {
 	})
 
 	document.getElementById("importJsonButton").addEventListener("click", importJson)
+	/**
+	 * This global event listener enables moving down the input fields in the main table using the 'Enter' key via Event Delegation.
+	 */
+	document.getElementById("table_main").addEventListener("keydown", function(event) {
+		if (event.target.tagName === "INPUT" && event.key === "Enter") {
+		let currentInput = event.target;
+		let currentRow = currentInput.closest("tr");
+		let nextRow = currentRow.nextElementSibling;
 
+		if (nextRow) {
+			let columnIndex = [...currentRow.cells].indexOf(currentInput.closest("td"));
+			let nextCell = nextRow.cells[columnIndex];
+
+			if (nextCell) {
+				let nextInput = nextCell.querySelector("input");
+				if (nextInput) {
+					nextInput.focus();
+				}
+			}
+		}
+		event.preventDefault();
+		}
+	});
 
 	// Floating info box
 	let info_escaped_text = new Table(document.getElementById("info_escaped_text"))

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -537,12 +537,13 @@ window.onload = function() {
 
 					// Populate the main inspection table
 					const mainTable = document.getElementById("table_main")
+					let mainTableColumnsCount = mainTable.querySelectorAll("thead tr th").length
 					let mainTableRowsCount = mainTable.rows.length - 1
 					let neededRows = jsonData.mainData.length
 
 					for (let i = mainTableRowsCount; i < neededRows; i++) {
 						let newRow = mainTable.insertRow()
-						for (let j = 0; j < 6; j++) { // This for loop will loop 6 times, one for each cell in the new row
+						for (let j = 0; j < mainTableColumnsCount; j++) {
 							let cell = newRow.insertCell(j)
 							if (j === 0) {
 								cell.textContent = i + 1 // Use i + 1 for the actual row number

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -537,6 +537,24 @@ window.onload = function() {
 
 					// Populate the main inspection table
 					const mainTable = document.getElementById("table_main")
+					let mainTableRowsCount = mainTable.rows.length - 1
+					let neededRows = jsonData.mainData.length
+
+					for (let i = mainTableRowsCount; i < neededRows; i++) {
+						let newRow = mainTable.insertRow()
+						for (let j = 0; j < 6; j++) { // This for loop will loop 6 times, one for each cell in the new row
+							let cell = newRow.insertCell(j)
+							if (j === 0) {
+								cell.textContent = i + 1 // Use i + 1 for the actual row number
+							} else {
+								let input = document.createElement('input')
+								let classes = ['pagenum', 'loc', 'param', 'actual', 'insptool']
+								input.classList.add(classes[j - 1])
+								cell.appendChild(input)
+							}
+						}
+					}
+
 					jsonData.mainData.forEach((item, index) => {
 						if (index < mainTable.rows.length - 1) {
 							mainTable.rows[index + 1].cells[0].textContent = item.itemNum

--- a/first-article-inspection-report/first-article-inspection-report.js
+++ b/first-article-inspection-report/first-article-inspection-report.js
@@ -492,28 +492,22 @@ window.onload = function() {
 
 					// Populate the main inspection table
 					const mainTable = document.getElementById("table_main")
-					let mainTableColumnsCount = mainTable.querySelectorAll("thead tr th").length
 					let mainTableRowsCount = mainTable.rows.length - 1
-					let neededRows = jsonData.mainData.length
+					let neededRowsCount = jsonData.mainData.length
 
 					// Remove any extra rows that are not in the imported file
-					for (let i = mainTableRowsCount; i > neededRows; i--) {
+					for (let i = mainTableRowsCount; i > neededRowsCount; i--) {
 						mainTable.deleteRow(i)
 					}
 
-					for (let i = mainTableRowsCount; i < neededRows; i++) {
-						let newRow = mainTable.insertRow()
-						for (let j = 0; j < mainTableColumnsCount; j++) {
-							let cell = newRow.insertCell(j)
-							if (j === 0) {
-								cell.textContent = i + 1 // Use i + 1 for the actual row number
-							} else {
-								let input = document.createElement('input')
-								let classes = ['pagenum', 'loc', 'param', 'actual', 'insptool']
-								input.classList.add(classes[j - 1])
-								cell.appendChild(input)
-							}
-						}
+					// Append necessary new rows
+					if (mainTableRowsCount < neededRowsCount) {
+						table_main.appendRows("body",
+						                      neededRowsCount - mainTableRowsCount,
+						                      table_main.heads.get("head").rows[0].cells.length,
+						                      rowFunc,
+						                      arrayToGenerator(table_main_cells, Infinity)
+						)
 					}
 
 					jsonData.mainData.forEach((item, index) => {


### PR DESCRIPTION
Fixes issue #10 

Add logic to dynamically insert additional rows into the main table when importing a JSON file that contains more rows than the default of 28.

- The rows are populated with corresponding data from the JSON file

- Adjusted the import process to check the number of rows in the JSON data and add any missing rows to match the data length